### PR TITLE
fixed  EOF while reading bug while value is "0"

### DIFF
--- a/src/clj/beamly_core/config.clj
+++ b/src/clj/beamly_core/config.clj
@@ -16,7 +16,7 @@
 (defn strip-leading-zeros
   "strips leading zeros from a string"
   [s]
-  (if (.startsWith s "0")
+  (if (and (.startsWith s "0") (not= (.length s) 1))
     (strip-leading-zeros (.substring s 1 (.length s)))
     s))
 


### PR DESCRIPTION
if config have a field which value is "0", compiler will throw "java.lang.RuntimeException: EOF while reading, compiling"